### PR TITLE
Implement sliding pane overlap effect

### DIFF
--- a/src/ScrollableTiledContainer.tsx
+++ b/src/ScrollableTiledContainer.tsx
@@ -8,6 +8,7 @@ const viewportStyle: CSSProperties = {
     overflowX: "hidden",
     overflowY: "hidden",
     border: "1px solid yellow",
+    position: "relative", // allow panes to be absolutely positioned
 };
 
 const trackStyle: CSSProperties = {
@@ -56,8 +57,28 @@ export function ScrollableTiledContainer({
     const totalWidth = paneWidth * panes.length;
     const offset = Math.max(0, totalWidth - bounds.width);   // px to slide left
 
+    const [first, ...rest] = panes;
+    const firstPeek = 60; // px of the first pane to keep visible when overlapped
+
     return (
         <div ref={viewportRef} style={viewportStyle}>
+            {offset > 0 && first && (
+                <ScrollableTiledPane
+                    key={first.id}
+                    width={paneWidth}
+                    style={panes.length > 1
+                      ? {
+                          position: "absolute",
+                          left: Math.max(-paneWidth, -offset + firstPeek),
+                          zIndex: 1,
+                        }
+                      : undefined}
+                >
+                    {typeof first.element === "function"
+                      ? (first.element as ScrollableTiledPaneRenderer)({ openPane })
+                      : first.element}
+                </ScrollableTiledPane>
+            )}
             <div
               style={{
                 ...trackStyle,
@@ -65,7 +86,7 @@ export function ScrollableTiledContainer({
                 transition: "transform 0.3s ease-out",
               }}
             >
-                {panes.map((p) => (
+                {(offset > 0 ? rest : panes).map((p) => (
                   <ScrollableTiledPane key={p.id} width={paneWidth}>
                     {typeof p.element === "function"
                       ? (p.element as ScrollableTiledPaneRenderer)({ openPane })

--- a/src/__tests__/ScrollableTiledContainer.test.tsx
+++ b/src/__tests__/ScrollableTiledContainer.test.tsx
@@ -2,10 +2,11 @@ import '../../tests/helpers/mockUseMeasure';      // ← registers the react-use
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ScrollableTiledContainer } from '../ScrollableTiledContainer';
+import { ScrollableTiledPaneData } from '../ScrollableTiledPane';
 
 const makeOpenerPane = (id: string, nextId: string, nextElement: React.ReactNode) => ({
   id,
-  element: ({ openPane }: { openPane: any }) => (
+  element: ({ openPane }: { openPane: (next: ScrollableTiledPaneData) => void }) => (
     <button onClick={() => openPane({ id: nextId, element: nextElement })}>
       {`open ${nextId}`}
     </button>


### PR DESCRIPTION
## Summary
- overlay the first pane when space runs out so new panes slide over it
- use a peek offset to keep a sliver of the first pane visible
- type the `openPane` argument in tests

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6862e9601540832abfa5e82edfc7bd6a