### PR TITLE
Add right side tab stacking

### DIFF
--- a/src/ScrollableTiledContainer.tsx
+++ b/src/ScrollableTiledContainer.tsx
@@ -14,7 +14,9 @@ const viewportStyle: CSSProperties = {
     display: "flex",
     flex: "1",
     width: "100%",
-    overflow: "hidden",
+    overflow: "hidden",                // keep clipping everything
+    scrollSnapType: "x mandatory",     // activate horizontal snap
+    scrollBehavior: "smooth",          // smooth programmatic motion
     position: "relative",
 };
 

--- a/src/ScrollableTiledContainer.tsx
+++ b/src/ScrollableTiledContainer.tsx
@@ -11,13 +11,13 @@ import { ScrollableTiledPane, ScrollableTiledPaneData, ScrollableTiledPaneRender
 import { VerticalTab } from "./VerticalTab";
 
 const viewportStyle: CSSProperties = {
+    position: "relative",
     display: "flex",
     flex: "1",
     width: "100%",
     overflow: "hidden",                // keep clipping everything
     scrollSnapType: "x mandatory",     // activate horizontal snap
     scrollBehavior: "smooth",          // smooth programmatic motion
-    position: "relative",
 };
 
 const trackStyle: CSSProperties = {

--- a/src/ScrollableTiledContainer.tsx
+++ b/src/ScrollableTiledContainer.tsx
@@ -107,7 +107,7 @@ export function ScrollableTiledContainer({
             willChange: "transform, opacity, box-shadow",
             opacity: 1,
             // shadow on the left side whenever the track has been shifted
-            boxShadow: "0 0 15px 3px rgba(0,0,0,0.05)",
+            boxShadow: "-6px 0 15px -3px rgba(0,0,0,0.05)",
         }),
     };
 
@@ -140,6 +140,7 @@ export function ScrollableTiledContainer({
             >
                 {rest.map(p => renderPane(p))}
             </div>
+            <div style={{ flexGrow : 1 }}/>
             {rightTabsElements}
         </div>
     );

--- a/src/ScrollableTiledContainer.tsx
+++ b/src/ScrollableTiledContainer.tsx
@@ -1,4 +1,11 @@
-import { CSSProperties, ReactNode, useCallback, useEffect, useState } from "react";
+import {
+    CSSProperties,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useState,
+    WheelEvent,
+} from "react";
 import useMeasure from "react-use-measure";
 import { ScrollableTiledPane, ScrollableTiledPaneData, ScrollableTiledPaneRenderer } from "./ScrollableTiledPane";
 import { VerticalTab } from "./VerticalTab";
@@ -33,9 +40,11 @@ export function ScrollableTiledContainer({
 }: Props): ReactNode {
     const [panes, setPanes] = useState<ScrollableTiledPaneData[]>(initial);
     const [viewportRef, bounds] = useMeasure();   // gives us bounds.width
+    const [viewIndex, setViewIndex] = useState(0);
 
     useEffect(() => {
         setPanes(initial);
+        setViewIndex(0);
     }, [initial]);
 
     /**
@@ -55,26 +64,27 @@ export function ScrollableTiledContainer({
 
     const paneWidth = Math.min(width, bounds.width);
 
-    /**
-     *  Calculates how many tabs should be collapsed into vertical tabs when panes exceed available width.
-     *   - Incrementally collapses panes from the left into vertical tabs
-     *   - Each collapsed pane frees up tabWidth pixels of space
-     *   - Stops when remaining panes can fit within available width with at most paneWidth overflow
-     */
-    let leftTabs = 0;
-    let available = bounds.width;
-    while (leftTabs < panes.length - 1) {
-        const remaining = panes.length - leftTabs;
-        const overflow = paneWidth * remaining - available;
-        if (overflow <= paneWidth - tabWidth) break;
-        leftTabs += 1;
-        available -= tabWidth;
-    }
+    const maxVisible = Math.max(1, Math.min(panes.length, Math.floor((bounds.width + (paneWidth - tabWidth)) / paneWidth)));
+
+    useEffect(() => {
+        setViewIndex((idx) => Math.min(Math.max(0, panes.length - maxVisible), idx));
+    }, [maxVisible]);
+
+    // keep newest panes visible
+    useEffect(() => {
+        setViewIndex(panes.length - maxVisible);
+    }, [panes.length, maxVisible]);
+
+    const leftTabs = viewIndex;
+    const visibleCount = Math.max(1, Math.min(maxVisible, panes.length - leftTabs));
+    const rightTabs = Math.max(0, panes.length - leftTabs - visibleCount);
 
     const tabs = panes.slice(0, leftTabs);
-    const [first, ...rest] = panes.slice(leftTabs);
+    const visible = panes.slice(leftTabs, leftTabs + visibleCount);
+    const [first, ...rest] = visible;
 
-    const offset = Math.max(0, paneWidth * (rest.length) - (available - paneWidth));
+    const available = bounds.width - (leftTabs + rightTabs) * tabWidth;
+    const offset = Math.max(0, paneWidth * visibleCount - available);
 
     const renderPane = (p: ScrollableTiledPaneData, extraStyle?: CSSProperties) => (
         <ScrollableTiledPane key={p.id} width={paneWidth} style={extraStyle}>
@@ -101,21 +111,36 @@ export function ScrollableTiledContainer({
         }),
     };
 
+    const rightTabsElements = panes.slice(leftTabs + visibleCount).map(t => (
+        <VerticalTab key={t.id} title={t.title} width={tabWidth} side="right" />
+    ));
+
     return (
-        <div ref={viewportRef} style={viewportStyle}>
+        <div
+            ref={viewportRef}
+            style={viewportStyle}
+            onWheel={(e: WheelEvent<HTMLDivElement>) => {
+                if (e.deltaX > 0 || e.deltaY > 0) {
+                    setViewIndex((v) => Math.min(panes.length - maxVisible, v + 1));
+                } else if (e.deltaX < 0 || e.deltaY < 0) {
+                    setViewIndex((v) => Math.max(0, v - 1));
+                }
+            }}
+        >
             {tabs.map(t => (
-                <VerticalTab key={t.id} title={t.title} width={tabWidth}/>
+                <VerticalTab key={t.id} title={t.title} width={tabWidth} />
             ))}
             {first &&
                 renderPane(first, offset > 0
-                    ? {position: "absolute", left: leftTabs * tabWidth}
-                    : {marginLeft: leftTabs * tabWidth})}
+                    ? { position: "absolute", left: leftTabs * tabWidth }
+                    : { marginLeft: leftTabs * tabWidth })}
             <div
                 data-testid="track"
-                style={{...trackStyle, left: leftTabs * tabWidth + paneWidth, ...slideStyle}}
+                style={{ ...trackStyle, left: leftTabs * tabWidth + paneWidth, ...slideStyle }}
             >
                 {rest.map(p => renderPane(p))}
             </div>
+            {rightTabsElements}
         </div>
     );
 }

--- a/src/ScrollableTiledPane.tsx
+++ b/src/ScrollableTiledPane.tsx
@@ -36,6 +36,7 @@ const basePaneStyle: CSSProperties = {
     flexGrow: "0",
     overflowY: "scroll",
     borderRight: "1px solid rgba(0,0,0,0.1)",
+    scrollSnapAlign: "start",
 };
 
 type Props = PropsWithChildren<{

--- a/src/VerticalTab.tsx
+++ b/src/VerticalTab.tsx
@@ -7,6 +7,7 @@ const baseStyle: CSSProperties = {
     justifyContent: "center",
     flexShrink: 0,
     boxShadow: "0 0 15px 3px rgba(0,0,0,0.05)",
+    scrollSnapAlign: "start",
 };
 
 const leftStyle: CSSProperties = {
@@ -33,7 +34,6 @@ export function VerticalTab({title, width, side = "left"}: Props) {
     const style: CSSProperties = {
         ...baseStyle,
         ...(side === "left" ? leftStyle : rightStyle),
-        scrollSnapAlign: "start",
         width,
     };
     return (

--- a/src/VerticalTab.tsx
+++ b/src/VerticalTab.tsx
@@ -33,6 +33,7 @@ export function VerticalTab({title, width, side = "left"}: Props) {
     const style: CSSProperties = {
         ...baseStyle,
         ...(side === "left" ? leftStyle : rightStyle),
+        scrollSnapAlign: "start",
         width,
     };
     return (

--- a/src/VerticalTab.tsx
+++ b/src/VerticalTab.tsx
@@ -1,29 +1,41 @@
 import { CSSProperties } from "react";
 
 const baseStyle: CSSProperties = {
-  backgroundColor: "white",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  flexShrink: 0,
-  boxShadow: "inset 0 0 15px 3px rgba(0,0,0,0.05)",
+    backgroundColor: "white",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    boxShadow: "0 0 15px 3px rgba(0,0,0,0.05)",
 };
 
-interface Props {
-  title: string;
-  width: number;
-  side?: 'left' | 'right';
+const leftStyle: CSSProperties = {
+    writingMode: "vertical-lr",
+    borderRight: "1px solid rgba(0,0,0,0.05)",
+    justifySelf: "flex-start",
+    boxShadow: "inset -6px 0 15px -3px rgba(0,0,0,0.05)",
+};
+
+const rightStyle: CSSProperties = {
+    writingMode: "vertical-rl",
+    borderLeft: "1px solid rgba(0,0,0,0.05)",
+    justifySelf: "flex-end",
+    boxShadow: "-6px 0 15px -3px rgba(0,0,0,0.05)",
 }
 
-export function VerticalTab({ title, width, side = 'left' }: Props) {
-  const style: CSSProperties = {
-    ...baseStyle,
-    width,
-    writingMode: side === 'left' ? 'vertical-lr' : 'vertical-rl',
-    borderRight: side === 'left' ? '1px solid rgba(0,0,0,0.05)' : undefined,
-    borderLeft: side === 'right' ? '1px solid rgba(0,0,0,0.05)' : undefined,
-  };
-  return (
-    <div data-testid="tab" style={style}>{title}</div>
-  );
+interface Props {
+    title: string;
+    width: number;
+    side?: "left" | "right";
+}
+
+export function VerticalTab({title, width, side = "left"}: Props) {
+    const style: CSSProperties = {
+        ...baseStyle,
+        ...(side === "left" ? leftStyle : rightStyle),
+        width,
+    };
+    return (
+        <div data-testid="tab" style={style}>{title}</div>
+    );
 }

--- a/src/VerticalTab.tsx
+++ b/src/VerticalTab.tsx
@@ -1,23 +1,29 @@
 import { CSSProperties } from "react";
 
-const tabStyle: CSSProperties = {
+const baseStyle: CSSProperties = {
   backgroundColor: "white",
-  writingMode: "vertical-lr",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
   flexShrink: 0,
-  borderRight: "1px solid rgba(0,0,0,0.05)",
   boxShadow: "inset 0 0 15px 3px rgba(0,0,0,0.05)",
 };
 
 interface Props {
   title: string;
   width: number;
+  side?: 'left' | 'right';
 }
 
-export function VerticalTab({ title, width }: Props) {
+export function VerticalTab({ title, width, side = 'left' }: Props) {
+  const style: CSSProperties = {
+    ...baseStyle,
+    width,
+    writingMode: side === 'left' ? 'vertical-lr' : 'vertical-rl',
+    borderRight: side === 'left' ? '1px solid rgba(0,0,0,0.05)' : undefined,
+    borderLeft: side === 'right' ? '1px solid rgba(0,0,0,0.05)' : undefined,
+  };
   return (
-    <div data-testid="tab" style={{...tabStyle, width}}>{title}</div>
+    <div data-testid="tab" style={style}>{title}</div>
   );
 }

--- a/src/__tests__/ScrollableTiledContainer.test.tsx
+++ b/src/__tests__/ScrollableTiledContainer.test.tsx
@@ -1,118 +1,118 @@
-import '../../tests/helpers/mockUseMeasure';      // ← registers the react-use-measure mock
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import "../../tests/helpers/mockUseMeasure"; // ← registers the react-use-measure mock
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ReactNode } from "react";
-import { ScrollableTiledContainer } from '../ScrollableTiledContainer';
+import { ScrollableTiledContainer } from "../ScrollableTiledContainer";
 
-import type { ScrollableTiledPaneData } from '../ScrollableTiledPane';
+import type { ScrollableTiledPaneData } from "../ScrollableTiledPane";
 
 type OpenPane = (next: ScrollableTiledPaneData) => void;
 
 const makeOpenerPane = (id: string, nextId: string, nextElement: ReactNode) => ({
-  id,
-  title: id,
-  element: ({ openPane }: { openPane: OpenPane }) => (
-    <button onClick={() => openPane({ id: nextId, title: nextId, element: nextElement })}>
-      {`open ${nextId}`}
-    </button>
-  ),
+    id,
+    title: id,
+    element: ({openPane}: { openPane: OpenPane }) => (
+        <button onClick={() => openPane({id: nextId, title: nextId, element: nextElement})}>
+            {`open ${nextId}`}
+        </button>
+    ),
 });
 
-it('appends a new pane and recalculates pane widths', async () => {
-  const user = userEvent.setup();
-  const width = 400;
+it("appends a new pane and recalculates pane widths", async () => {
+    const user = userEvent.setup();
+    const width = 400;
 
-  // 1️⃣  one opener pane that can add pane “B”
-  const initial = [
-    makeOpenerPane('A', 'B', <span>B-content</span>),
-  ];
+    // 1️⃣  one opener pane that can add pane “B”
+    const initial = [
+        makeOpenerPane("A", "B", <span>B-content</span>),
+    ];
 
-  render(<ScrollableTiledContainer initial={initial} width={width} />);
+    render(<ScrollableTiledContainer initial={initial} width={width}/>);
 
-  // → initially exactly one .pane with full width (= 800 px from mock)
-  let panes = screen.getAllByTestId('pane');
-  expect(panes).toHaveLength(1);
-  expect(panes[0]).toHaveStyle({ width: '400px' });
+    // → initially exactly one .pane with full width (= 800 px from mock)
+    let panes = screen.getAllByTestId("pane");
+    expect(panes).toHaveLength(1);
+    expect(panes[0]).toHaveStyle({width: "400px"});
 
-  // 2️⃣  click button inside first pane to open B
-  await user.click(screen.getByRole('button', { name: /open B/i }));
+    // 2️⃣  click button inside first pane to open B
+    await user.click(screen.getByRole("button", {name: /open B/i}));
 
-  // → now two panes, both 400 px wide (800 px / 2)
-  panes = screen.getAllByTestId('pane');
-  expect(panes).toHaveLength(2);
-  panes.forEach(p => expect(p).toHaveStyle({ width: '400px' }));
+    // → now two panes, both 400 px wide (800 px / 2)
+    panes = screen.getAllByTestId("pane");
+    expect(panes).toHaveLength(2);
+    panes.forEach(p => expect(p).toHaveStyle({width: "400px"}));
 
-  // and the new pane’s content is rendered
-  expect(screen.getByText('B-content')).toBeInTheDocument();
+    // and the new pane’s content is rendered
+    expect(screen.getByText("B-content")).toBeInTheDocument();
 });
 
-it('slides panes over the first when width is limited', async () => {
-  const user = userEvent.setup();
-  const minWidth = 300;
+it("slides panes over the first when width is limited", async () => {
+    const user = userEvent.setup();
+    const minWidth = 300;
 
-  const paneC = { id: 'C', title: 'C', element: <span>C-content</span> };
-  const paneB = makeOpenerPane('B', 'C', <span>C-content</span>);
-  paneB.element = ({ openPane }: { openPane: OpenPane }) => (
-    <button onClick={() => openPane(paneC)}>open C</button>
-  );
+    const paneC = {id: "C", title: "C", element: <span>C-content</span>};
+    const paneB = makeOpenerPane("B", "C", <span>C-content</span>);
+    paneB.element = ({openPane}: { openPane: OpenPane }) => (
+        <button onClick={() => openPane(paneC)}>open C</button>
+    );
 
-  const initial = [
-    {
-      id: 'A',
-      title: 'A',
-      element: ({ openPane }: { openPane: OpenPane }) => (
-        <button onClick={() => openPane(paneB)}>open B</button>
-      ),
-    },
-  ];
+    const initial = [
+        {
+            id: "A",
+            title: "A",
+            element: ({openPane}: { openPane: OpenPane }) => (
+                <button onClick={() => openPane(paneB)}>open B</button>
+            ),
+        },
+    ];
 
-  render(<ScrollableTiledContainer initial={initial} width={minWidth} />);
+    render(<ScrollableTiledContainer initial={initial} width={minWidth}/>);
 
-  await user.click(screen.getByRole('button', { name: /open B/i }));
-  await user.click(screen.getByRole('button', { name: /open C/i }));
+    await user.click(screen.getByRole("button", {name: /open B/i}));
+    await user.click(screen.getByRole("button", {name: /open C/i}));
 
-  const panes = screen.getAllByTestId('pane');
-  expect(panes).toHaveLength(3);
-  panes.forEach((p) => expect(p).toHaveStyle({ width: '300px' }));
-  expect(panes[0]).toHaveStyle({ position: 'absolute' });
+    const panes = screen.getAllByTestId("pane");
+    expect(panes).toHaveLength(3);
+    panes.forEach((p) => expect(p).toHaveStyle({width: "300px"}));
+    expect(panes[0]).toHaveStyle({position: "absolute"});
 
-  const track = screen.getByTestId('track');
-  expect(track).toHaveStyle({ transform: 'translateX(-100px)' });
+    const track = screen.getByTestId("track");
+    expect(track).toHaveStyle({transform: "translateX(-100px)"});
 });
 
-it('creates vertical tabs when panes exceed available width', async () => {
-  const user = userEvent.setup();
-  const width = 300;
+it("creates vertical tabs when panes exceed available width", async () => {
+    const user = userEvent.setup();
+    const width = 300;
 
-  const paneD = { id: 'D', title: 'D', element: <span>D-content</span> };
-  const paneC = makeOpenerPane('C', 'D', <span>D-content</span>);
-  paneC.element = ({ openPane }: { openPane: OpenPane }) => (
-    <button onClick={() => openPane(paneD)}>open D</button>
-  );
-  const paneB = makeOpenerPane('B', 'C', <span>C-content</span>);
-  paneB.element = ({ openPane }: { openPane: OpenPane }) => (
-    <button onClick={() => openPane(paneC)}>open C</button>
-  );
+    const paneD = {id: "D", title: "D", element: <span>D-content</span>};
+    const paneC = makeOpenerPane("C", "D", <span>D-content</span>);
+    paneC.element = ({openPane}: { openPane: OpenPane }) => (
+        <button onClick={() => openPane(paneD)}>open D</button>
+    );
+    const paneB = makeOpenerPane("B", "C", <span>C-content</span>);
+    paneB.element = ({openPane}: { openPane: OpenPane }) => (
+        <button onClick={() => openPane(paneC)}>open C</button>
+    );
 
-  const initial = [
-    {
-      id: 'A',
-      title: 'A',
-      element: ({ openPane }: { openPane: OpenPane }) => (
-        <button onClick={() => openPane(paneB)}>open B</button>
-      ),
-    },
-  ];
+    const initial = [
+        {
+            id: "A",
+            title: "A",
+            element: ({openPane}: { openPane: OpenPane }) => (
+                <button onClick={() => openPane(paneB)}>open B</button>
+            ),
+        },
+    ];
 
-  render(<ScrollableTiledContainer initial={initial} width={width} />);
+    render(<ScrollableTiledContainer initial={initial} width={width}/>);
 
-  await user.click(screen.getByRole('button', { name: /open B/i }));
-  await user.click(screen.getByRole('button', { name: /open C/i }));
-  await user.click(screen.getByRole('button', { name: /open D/i }));
+    await user.click(screen.getByRole("button", {name: /open B/i}));
+    await user.click(screen.getByRole("button", {name: /open C/i}));
+    await user.click(screen.getByRole("button", {name: /open D/i}));
 
-  expect(screen.getAllByTestId('pane')).toHaveLength(3);
-  expect(screen.getAllByTestId('tab')).toHaveLength(1);
+    expect(screen.getAllByTestId("pane")).toHaveLength(3);
+    expect(screen.getAllByTestId("tab")).toHaveLength(1);
 
-  const track = screen.getByTestId('track');
-  expect(track).toHaveStyle({ transform: 'translateX(-140px)' });
+    const track = screen.getByTestId("track");
+    expect(track).toHaveStyle({transform: "translateX(-140px)"});
 });


### PR DESCRIPTION
## Summary
- add scrolling index state to switch visible panes
- compute right-side tabs and handle wheel scrolling
- allow VerticalTab to mirror on right side

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68632e778ac4832aa72ccb7b3a4e6087