### PR TITLE
Add example React app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ function App() {
 }
 ```
 
+## Example app
+Run the demo application from the `example` folder:
+
+```bash
+cd example
+pnpm install
+pnpm dev
+```
+
 ## API
 ### `ScrollableTiledContainer`
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scrollable Panes Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "scrollable-panes-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-scrollable-panes": "file:.."
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,0 +1,21 @@
+import { ScrollableTiledContainer, ScrollableTiledPaneData } from 'react-scrollable-panes';
+
+const initial: ScrollableTiledPaneData[] = [
+  {
+    id: 'home',
+    title: 'Home',
+    element: ({ openPane }) => (
+      <button onClick={() => openPane({
+        id: 'details',
+        title: 'Details',
+        element: <div>Details pane</div>
+      })}>
+        Open details
+      </button>
+    )
+  }
+];
+
+export default function App() {
+  return <ScrollableTiledContainer initial={initial} width={380} />;
+}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add an `example` folder with a small Vite/React app
- document how to run the example in the README

## Testing
- `pnpm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6863f14ff9b8832abb3aa63f6ca251e6